### PR TITLE
Use latest version of astropy to avoid test failures on appveyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,6 @@ os:
 # Use Travis' container-based architecture
 sudo: false
 
-addons:
-  apt:
-    packages:
-    - graphviz
-    - texlive-latex-extra
-    - dvipng
-
 env:
     global:
         # The following versions are the 'default' for tests, unless

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
       PYTEST_VERSION: "3.2"
       PYTEST_COMMAND: "pytest"
       NUMPY_VERSION: "stable"
-      ASTROPY_VERSION: "latest"
+      ASTROPY_VERSION: "development"
       CONDA_DEPENDENCIES: "six"
       PYTHON_ARCH: "64"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
       PYTEST_VERSION: "3.2"
       PYTEST_COMMAND: "pytest"
       NUMPY_VERSION: "stable"
-      ASTROPY_VERSION: "stable"
+      ASTROPY_VERSION: "latest"
       CONDA_DEPENDENCIES: "six"
       PYTHON_ARCH: "64"
 


### PR DESCRIPTION
The PR https://github.com/astropy/astropy/pull/6651 should have fixed the issue that was causing test failures on Windows. Now that it has been merged, we should be able to build against the latest version of astropy to make the failures go away.

Also remove an extraneous section from the travis config file. 