### PR TITLE
Remove test dependency on astropy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ env:
         - PYTEST_VERSION=3.2
         - PYTEST_COMMAND='pytest'
         - NUMPY_VERSION=stable
-        - ASTROPY_VERSION=stable
         - CONDA_DEPENDENCIES='six'
 
     matrix:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
 
 - Update list of valid hosts URLs recognized as astropy data sources. [#13]
 
+- Remove test dependency on astropy core. [#14]
+
 0.1 (2017-10-10)
 ================
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,6 @@ environment:
       PYTEST_VERSION: "3.2"
       PYTEST_COMMAND: "pytest"
       NUMPY_VERSION: "stable"
-      ASTROPY_VERSION: "stable"
       CONDA_DEPENDENCIES: "six"
       PYTHON_ARCH: "64"
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ setup(
     ],
     keywords=[ 'remote', 'data', 'pytest', 'py.test' ],
     install_requires=[ 'six', 'pytest>=2.8.0' ],
-    tests_require=['astropy'],
     python_requires='>=2.7',
     entry_points={
         'pytest11': [

--- a/tests/test_skip_remote_data.py
+++ b/tests/test_skip_remote_data.py
@@ -3,9 +3,17 @@
 # by run_tests because it has the remote_data decorator.
 
 import pytest
+from contextlib import closing
+from six.moves.urllib.request import urlopen
 
-from astropy.utils.data import conf, download_file
 
+ASTROPY_DATA_URL = "http://data.astropy.org/"
+TIMEOUT = 10
+
+
+def download_file(remote_url):
+    with closing(urlopen(remote_url, timeout=TIMEOUT)) as remote:
+        remote.read()
 
 @pytest.mark.remote_data
 def test_skip_remote_data(pytestconfig):
@@ -19,7 +27,7 @@ def test_skip_remote_data(pytestconfig):
         pytest.fail('@remote_data was not skipped with remote_data=astropy')
 
     # Test Astropy URL
-    download_file(conf.dataurl + 'galactic_center/gc_2mass_k.fits')
+    download_file(ASTROPY_DATA_URL + 'galactic_center/gc_2mass_k.fits')
 
     # Test non-Astropy URL
     download_file('http://www.google.com')
@@ -35,7 +43,7 @@ def test_skip_remote_data_astropy(pytestconfig):
         pytest.fail('@remote_data was not skipped with remote_data=none')
 
     # Test Astropy URL
-    download_file(conf.dataurl + 'galactic_center/gc_2mass_k.fits')
+    download_file(ASTROPY_DATA_URL + 'galactic_center/gc_2mass_k.fits')
 
     # Test non-Astropy URL
     if pytestconfig.getoption('remote_data') == 'astropy':


### PR DESCRIPTION
This fixes #11. This required a local (and simplified) implementation of `download_file`.

@astrofrog, I wonder if those kinds of utilities belong in a separate package themselves?