### PR TITLE
Allow remote_data argument to be passed without keyword...

### DIFF
--- a/pytest_remotedata/plugin.py
+++ b/pytest_remotedata/plugin.py
@@ -65,7 +65,11 @@ def pytest_runtest_setup(item):
         raise ValueError("remote_data and internet_off are not compatible")
 
     if remote_data is not None:
-        source = remote_data.kwargs.get('source', 'any')
+        if len(remote_data.args) > 0:
+            source = remote_data.args[0]
+        else:
+            source = remote_data.kwargs.get('source', 'any')
+
         if source not in ('astropy', 'any'):
             raise ValueError("source should be 'astropy' or 'any'")
 


### PR DESCRIPTION
This is to accommodate a use case that apparently already exists but hasn't been working properly. The original intent appears to be for the `remote_data` decorator to be used this way:

```python
@pytest.mark.remote_data(source='astropy')
def test_whatever():
   ...
```

However, many tests in Astropy (and presumably elsewhere) have used it the following way:
```python
@pytest.mark.remote_data('astropy')
def test_whatever():
   ...
```

This latter case was not properly supported by the plugin until this PR, so apparently it hasn't been working for some tests for quite some time. However, it wasn't noticed until very recently.

This fixes #26.