### PR TITLE
Include tests in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,4 +4,6 @@ include CHANGES.rst
 
 include setup.cfg
 
+recursive-include tests *
+
 global-exclude *.pyc *.o


### PR DESCRIPTION
Tests are used by some downstreams to verify the build was done correctly.