### PR TITLE
Resolving warnings due to markers and configuration

### DIFF
--- a/pytest_remotedata/plugin.py
+++ b/pytest_remotedata/plugin.py
@@ -5,6 +5,7 @@ make use of online data.
 """
 import pytest
 from .disable_internet import turn_off_internet, turn_on_internet
+from distutils.version import StrictVersion
 
 
 def pytest_addoption(parser):
@@ -61,8 +62,12 @@ def pytest_unconfigure():
 
 def pytest_runtest_setup(item):
 
-    remote_data = item.get_closest_marker('remote_data')
-    internet_off = item.get_closest_marker('internet_off')
+    if StrictVersion(pytest.__version__) < StrictVersion("3.6"):
+        remote_data = item.get_marker('remote_data')
+        internet_off = item.get_marker('internet_off')
+    else:
+        remote_data = item.get_closest_marker('remote_data')
+        internet_off = item.get_closest_marker('internet_off')
 
     remote_data_config = item.config.getvalue("remote_data")
 

--- a/pytest_remotedata/plugin.py
+++ b/pytest_remotedata/plugin.py
@@ -61,8 +61,8 @@ def pytest_unconfigure():
 
 def pytest_runtest_setup(item):
 
-    remote_data = item.get_marker('remote_data')
-    internet_off = item.get_marker('internet_off')
+    remote_data = item.get_closest_marker('remote_data')
+    internet_off = item.get_closest_marker('internet_off')
 
     remote_data_config = item.config.getvalue("remote_data")
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[pytest]
+[tool:pytest]
 minversion = 3.1
 testpaths = tests
 remote_data_strict = true


### PR DESCRIPTION
This pull request resolves the warnings due to deprecated MarkInfo objects like:

```
C:\Miniconda3\envs\remoteData\lib\site-packages\pytest_remotedata-0.3.1.dev0-py3.7.egg\pytest_remotedata\plugin.py:73: RemovedInPytest4Warning: MarkInfo objects are deprecated as they contain merged marks which are hard to deal with correctly.
Please use node.get_closest_marker(name) or node.iter_markers(name).
Docs: https://docs.pytest.org/en/latest/mark.html#updating-code
  if len(remote_data.args) > 0:
C:\Miniconda3\envs\remoteData\lib\site-packages\pytest_remotedata-0.3.1.dev0-py3.7.egg\pytest_remotedata\plugin.py:76: RemovedInPytest4Warning: MarkInfo objects are deprecated as they contain merged marks which are hard to deal with correctly.
Please use node.get_closest_marker(name) or node.iter_markers(name).
Docs: https://docs.pytest.org/en/latest/mark.html#updating-code
  source = remote_data.kwargs.get('source', 'any')
```

and also from deprecated configuration

```
C:\Miniconda3\envs\remoteData\lib\site-packages\_pytest\config\findpaths.py:42: RemovedInPytest4Warning: [pytest] section in setup.cfg files is deprecated, use [tool:pytest] instead.
  config=config,
```

Should close #31 