### PR TITLE
Use [tool:pytest] to fix build on pytest 4.2

### DIFF
--- a/tests/test_strict_check.py
+++ b/tests/test_strict_check.py
@@ -18,7 +18,7 @@ PYFILE_CONTENTS = """
 def _write_config_file(testdir, entry):
     config = testdir.tmpdir.join('setup.cfg')
     config.write("""
-[pytest]
+[tool:pytest]
 {}
         """.format(entry))
 


### PR DESCRIPTION
[pytest] marking is deprecated and errors out on 4.2+ version.