### PR TITLE
Using LooseVersion to be compatible with pytest versioning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
         # overidden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
         - PYTHON_VERSION=3.6
-        - PYTEST_VERSION=3.6
+        - PYTEST_VERSION=4.6
         - PYTEST_COMMAND='pytest'
         - NUMPY_VERSION=stable
         - CONDA_DEPENDENCIES='six'
@@ -25,9 +25,9 @@ env:
         - PYTHON_VERSION=2.7
         - PYTHON_VERSION=3.5
         - PYTHON_VERSION=3.6 PYTEST_VERSION=3.4
-        - PYTHON_VERSION=3.6 PYTEST_VERSION=3.5
+        - PYTHON_VERSION=3.6 PYTEST_VERSION=4.5
         - PYTHON_VERSION=3.6
-        - PYTHON_VERSION=3.7
+        - PYTHON_VERSION=3.7 PYTEST_VERSION=5.0
 
 matrix:
     include:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,6 @@ environment:
       PYTHON: "C:\\conda"
       MINICONDA_VERSION: "latest"
       CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
-      PYTEST_VERSION: "3.6"
       PYTEST_COMMAND: "pytest"
       NUMPY_VERSION: "stable"
       CONDA_DEPENDENCIES: "six"
@@ -23,6 +22,7 @@ environment:
         platform: x64
 
       - PYTHON_VERSION: "3.5"
+        NUMPY_VERSION: "1.15"
         platform: x64
 
       - PYTHON_VERSION: "3.6"
@@ -30,13 +30,14 @@ environment:
         platform: x64
 
       - PYTHON_VERSION: "3.6"
-        PYTEST_VERSION: "3.5"
+        PYTEST_VERSION: "4.1"
         platform: x64
 
       - PYTHON_VERSION: "3.6"
         platform: x64
 
       - PYTHON_VERSION: "3.7"
+        PYTEST_VERSION: "5.0"
         platform: x64
 
 install:

--- a/pytest_remotedata/plugin.py
+++ b/pytest_remotedata/plugin.py
@@ -5,7 +5,7 @@ make use of online data.
 """
 import pytest
 from .disable_internet import turn_off_internet, turn_on_internet
-from distutils.version import StrictVersion
+from distutils.version import LooseVersion
 
 
 def pytest_addoption(parser):
@@ -62,7 +62,7 @@ def pytest_unconfigure():
 
 def pytest_runtest_setup(item):
 
-    if StrictVersion(pytest.__version__) < StrictVersion("3.6"):
+    if LooseVersion(pytest.__version__) < LooseVersion("3.6"):
         remote_data = item.get_marker('remote_data')
         internet_off = item.get_marker('internet_off')
     else:


### PR DESCRIPTION
This is to fix #39 

This can/should be backported to the 0.3.x branch in case we plan to have another release from there.

 