### PR TITLE
List possible values in error message

### DIFF
--- a/pytest_remotedata/plugin.py
+++ b/pytest_remotedata/plugin.py
@@ -34,9 +34,11 @@ def pytest_configure(config):
     strict_check = bool(config.getini('remote_data_strict'))
 
     remote_data = config.getoption('remote_data')
-    if remote_data not in ['astropy', 'any', 'github', 'none']:
+    options = ['astropy', 'any', 'github', 'none']
+    if remote_data not in options:
         raise pytest.UsageError(
-            "'{}' is not a valid source for remote data".format(remote_data))
+            "'{}' is not a valid source for remote data, "
+            "use one of '{}'".format(remote_data, "', '".join(options)))
 
     # Monkeypatch to deny access to remote resources unless explicitly told
     # otherwise


### PR DESCRIPTION
Because I can never remember whether it's `'all'` or `'any'`...

```
$ ~/munka/devel/astropy [:36557b988|✚ 1⚑ 22] $ pytest --remote-data=all astropy/coordinates/sky_coordinate.py
ERROR: 'all' is not a valid source for remote data, use one of 'astropy', 'any', 'github', 'none'
```

vs
```
$ ~/munka/devel/astropy [:36557b988|✚ 1⚑ 22] $ pytest --remote-data=all astropy/coordinates/sky_coordinate.py
ERROR: 'all' is not a valid source for remote data
```

