### PR TITLE
TST: Do not use conda for OSX and Windows jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ matrix:
 install:
     - if [[ $TRAVIS_OS_NAME == osx || $TRAVIS_OS_NAME == windows ]]; then
         git clone git://github.com/astropy/ci-helpers.git;
-        source ci-helpers/travis/setup_conda.sh;
+        source ci-helpers/travis/setup_python.sh;
       fi
 
 script:

--- a/README.rst
+++ b/README.rst
@@ -97,8 +97,8 @@ remote data sources in addition to ``astropy``.
 Development Status
 ------------------
 
-.. image:: https://travis-ci.org/astropy/pytest-remotedata.svg
-    :target: https://travis-ci.org/astropy/pytest-remotedata
+.. image:: https://travis-ci.com/astropy/pytest-remotedata.svg
+    :target: https://travis-ci.com/astropy/pytest-remotedata
     :alt: Travis CI Status
 
 Questions, bug reports, and feature requests can be submitted on `github`_.


### PR DESCRIPTION
This will hopefully fix chronic Windows failure. Same patch as the one we applied to `astropy`.

Current error:
```
FileNotFoundError: [Errno 2] No such file or directory: 'c:\\tools\\miniconda3\\envs\\test\\Lib\\venv\\scripts\\nt\\python.exe'
```

Also change link to Travis badge.