### PR TITLE
Remove six

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ It was originally part of the `astropy`_ core package, but has been moved to a
 separate package in order to be of more general use.
 
 .. _pytest: https://pytest.org/en/latest/
-.. _astropy: https://astropy.org/en/latest/
+.. _astropy: https://astropy.org/
 
 
 Motivation

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ repository::
 
     $ git clone https://github.com/astropy/pytest-remotedata
     $ cd pytest-remotedata
-    $ python ./setup.py install
+    $ pip install .
 
 In either case, the plugin will automatically be registered for use with
 ``pytest``.

--- a/pytest_remotedata/disable_internet.py
+++ b/pytest_remotedata/disable_internet.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import contextlib
 import socket
-import urllib
+import urllib.request
 
 # save original socket method for restoration
 # These are global so that re-calling the turn_off_internet function doesn't

--- a/pytest_remotedata/disable_internet.py
+++ b/pytest_remotedata/disable_internet.py
@@ -1,8 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import contextlib
 import socket
-
-from six.moves import urllib
+import urllib
 
 # save original socket method for restoration
 # These are global so that re-calling the turn_off_internet function doesn't

--- a/tests/test_skip_remote_data.py
+++ b/tests/test_skip_remote_data.py
@@ -2,23 +2,16 @@
 # this test doesn't actually use any online data, it should just be skipped
 # by run_tests because it has the remote_data decorator.
 
-import pytest
 from contextlib import closing
+from urllib.error import URLError
+from urllib.request import urlopen
 
-import six
-from six.moves.urllib.request import urlopen
-
+import pytest
 
 ASTROPY_DATA_URL = "http://data.astropy.org/"
 GITHUB_DATA_URL = "http://astropy.github.io/"
 EXTERNAL_URL = "http://www.google.com"
 TIMEOUT = 10
-
-if six.PY2:
-    _EXPECTED_ERROR = IOError
-else:
-    from six.moves.urllib.error import URLError
-    _EXPECTED_ERROR = URLError
 
 
 def download_file(remote_url):
@@ -97,13 +90,13 @@ def test_internet_off_decorator(pytestconfig):
 
 def test_block_internet_connection(pytestconfig):
     if pytestconfig.getoption('remote_data') == 'none':
-        with pytest.raises(_EXPECTED_ERROR):
+        with pytest.raises(URLError):
             download_file(EXTERNAL_URL)
     elif pytestconfig.getoption('remote_data') == 'astropy':
-        with pytest.raises(_EXPECTED_ERROR):
+        with pytest.raises(URLError):
             download_file(EXTERNAL_URL)
     elif pytestconfig.getoption('remote_data') == 'github':
-        with pytest.raises(_EXPECTED_ERROR):
+        with pytest.raises(URLError):
             download_file(EXTERNAL_URL)
     else:
         download_file(EXTERNAL_URL)
@@ -111,5 +104,5 @@ def test_block_internet_connection(pytestconfig):
 
 @pytest.mark.internet_off
 def test_block_internet_connection_internet_off():
-    with pytest.raises(_EXPECTED_ERROR):
+    with pytest.raises(URLError):
         download_file(EXTERNAL_URL)

--- a/tests/test_socketblocker.py
+++ b/tests/test_socketblocker.py
@@ -1,14 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import sys
 import time
-
+from http.server import HTTPServer, SimpleHTTPRequestHandler
 from threading import Thread
-
-from six.moves import BaseHTTPServer, SimpleHTTPServer
-from six.moves.urllib.request import urlopen
+from urllib.request import urlopen
 
 import pytest
-
 from pytest_remotedata.disable_internet import no_internet
 
 
@@ -18,7 +15,7 @@ def test_outgoing_fails():
             urlopen('http://www.python.org')
 
 
-class StoppableHTTPServer(BaseHTTPServer.HTTPServer, object):
+class StoppableHTTPServer(HTTPServer, object):
     def __init__(self, *args):
         super(StoppableHTTPServer, self).__init__(*args)
         self.stop = False
@@ -44,8 +41,7 @@ def test_localconnect_succeeds(localhost):
 
     # port "0" means find open port
     # see http://stackoverflow.com/questions/1365265/on-localhost-how-to-pick-a-free-port-number
-    httpd = StoppableHTTPServer(('localhost', 0),
-                                SimpleHTTPServer.SimpleHTTPRequestHandler)
+    httpd = StoppableHTTPServer(('localhost', 0), SimpleHTTPRequestHandler)
 
     port = httpd.socket.getsockname()[1]
 

--- a/tests/test_strict_check.py
+++ b/tests/test_strict_check.py
@@ -5,7 +5,7 @@ import pytest
 
 PYFILE_CONTENTS = """
     import pytest
-    from six.moves.urllib.request import urlopen
+    from urllib.request import urlopen
 
     def test_config_setting(pytestconfig):
         assert pytestconfig.getini('remote_data_strict') == {}


### PR DESCRIPTION
It seems six was still used here, though not declared in the dependencies.
I also fixed a link to astropy.org and replaced `python setup.py` with pip.