### PR TITLE
MNT: Replace master with main

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -3,7 +3,7 @@ name: Run unit tests
 on:
   pull_request:
   push:
-    branches: [ master ]
+    branches: [ main ]
     tags:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
This PR attempts to replace all mention of `master` to `main` in this repository. This should be reviewed and merged right after the maintainer has renamed the default branch.

This is an automated update made by the `batchpr` tool :robot: - feel free to close if it doesn't look good! You can report issues to @pllim.