### PR TITLE
CI: update versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,10 +13,10 @@ jobs:
     if: ((github.event_name == 'push' && startsWith(github.ref, 'refs/tags')) || contains(github.event.pull_request.labels.*.name, 'Build wheels'))
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.8
 

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -17,13 +17,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
-            python-version: 3.6
-            toxenv: py36-test-pytest46
-          - os: windows-latest
-            python-version: 3.6
-            toxenv: py36-test-pytest50
           - os: macos-latest
+            python-version: 3.7
+            toxenv: py37-test-pytest46
+          - os: ubuntu-latest
+            python-version: 3.7
+            toxenv: py37-test-pytest50
+          - os: ubuntu-latest
             python-version: 3.7
             toxenv: py37-test-pytest51
           - os: ubuntu-latest

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -43,10 +43,10 @@ jobs:
             toxenv: py310-test-pytest71
           - os: macos-latest
             python-version: '3.11'
-            toxenv: py310-test-pytest72
+            toxenv: py311-test-pytest72
           - os: ubuntu-latest
             python-version: '3.11'
-            toxenv: py310-test-pytestdev
+            toxenv: py311-test-pytestdev
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -46,11 +46,11 @@ jobs:
             toxenv: py310-test-pytestdev
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Tox

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -26,7 +26,7 @@ jobs:
           - os: ubuntu-latest
             python-version: 3.7
             toxenv: py37-test-pytest51
-          - os: ubuntu-latest
+          - os: windows-latest
             python-version: 3.7
             toxenv: py37-test-pytest52
           - os: windows-latest
@@ -42,7 +42,10 @@ jobs:
             python-version: '3.10'
             toxenv: py310-test-pytest71
           - os: macos-latest
-            python-version: '3.10'
+            python-version: '3.11'
+            toxenv: py310-test-pytest72
+          - os: ubuntu-latest
+            python-version: '3.11'
             toxenv: py310-test-pytestdev
 
     steps:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 - ``-R`` is added as a short version for the command-line option
   ``--remote-data``. [#62]
 
+- Versions of Python <3.7 are no longer supported. [#65]
+
 0.3.3 (2021-12-21)
 ==================
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,9 @@ classifiers =
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Software Development :: Testing
     Topic :: Utilities

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,6 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: Implementation :: CPython
@@ -27,7 +26,7 @@ keywords = remote, data, pytest, py.test
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 setup_requires =
     setuptools_scm
 install_requires =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,38,39,310}-test{,-devdeps}
+    py{37,38,39,310,311}-test{,-devdeps}
     codestyle
 requires =
     setuptools >= 30.3.0
@@ -19,6 +19,7 @@ deps =
     pytest60: pytest==6.0.*
     pytest61: pytest==6.1.*
     pytest71: pytest==7.1.*
+    pytest72: pytest==7.2.*
     pytestdev: git+https://github.com/pytest-dev/pytest#egg=pytest
 
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38,39,310}-test{,-devdeps}
+    py{37,38,39,310}-test{,-devdeps}
     codestyle
 requires =
     setuptools >= 30.3.0


### PR DESCRIPTION
cron started to fail, time to drop 3.6 support. (not yet dropping 3.7 as pytest proper still has it, as it doesn't require anything here atm to keep the support)