### PR TITLE
Replace deprecated code

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,3 +48,4 @@ exclude =
 minversion = 4.6
 testpaths = tests
 remote_data_strict = true
+filterwarnings = error

--- a/tests/test_socketblocker.py
+++ b/tests/test_socketblocker.py
@@ -51,6 +51,7 @@ def test_localconnect_succeeds(localhost):
     time.sleep(0.1)
 
     urlopen('http://{localhost:s}:{port:d}'.format(localhost=localhost, port=port)).close()
+    httpd.server_close()
 
 
 # Used for the below test--inline functions aren't pickleable

--- a/tests/test_socketblocker.py
+++ b/tests/test_socketblocker.py
@@ -45,7 +45,7 @@ def test_localconnect_succeeds(localhost):
     port = httpd.socket.getsockname()[1]
 
     server = Thread(target=httpd.serve_forever)
-    server.setDaemon(True)
+    server.daemon = True
 
     server.start()
     time.sleep(0.1)


### PR DESCRIPTION
The first commit replaces a method call that is [deprecated since Python 3.10](https://docs.python.org/3.10/library/threading.html#threading.Thread.setDaemon) and fixes #68. The second commit configures `pytest` to convert uncaught warnings to errors, which would have revealed the deprecation earlier.