### PR TITLE
Workaround: Remove -R option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,8 @@
 0.4.1 (unreleased)
 ==================
 
-- No changes yet.
+- Reverting the short option of ``-R`` due to a clash with ``pytest-leaks``.
+  The short option is added to ``pytest-astropy`` instead. [#70]
 
 0.4.0 (2022-12-11)
 ==================

--- a/pytest_remotedata/plugin.py
+++ b/pytest_remotedata/plugin.py
@@ -14,8 +14,9 @@ def pytest_addoption(parser):
     # is 'none', but if it is specified without arguments (--remote-data), it
     # defaults to '--remote-data=any'.
     parser.addoption(
-        help="run tests with online data")
         "--remote-data", nargs="?", const='any', default='none',
+        help="run tests with online data",
+        choices=['astropy', 'any', 'github', 'none'])
 
     parser.addini(
         'remote_data_strict',
@@ -34,11 +35,6 @@ def pytest_configure(config):
     strict_check = bool(config.getini('remote_data_strict'))
 
     remote_data = config.getoption('remote_data')
-    options = ['astropy', 'any', 'github', 'none']
-    if remote_data not in options:
-        raise pytest.UsageError(
-            "'{}' is not a valid source for remote data, "
-            "use one of '{}'".format(remote_data, "', '".join(options)))
 
     # Monkeypatch to deny access to remote resources unless explicitly told
     # otherwise

--- a/pytest_remotedata/plugin.py
+++ b/pytest_remotedata/plugin.py
@@ -12,10 +12,10 @@ def pytest_addoption(parser):
 
     # The following means that if --remote-data is not specified, the default
     # is 'none', but if it is specified without arguments (--remote-data), it
-    # defaults to '--remote-data=any'. -R is short for --remote-data
+    # defaults to '--remote-data=any'.
     parser.addoption(
-        "--remote-data", "-R", nargs="?", const='any', default='none',
         help="run tests with online data")
+        "--remote-data", nargs="?", const='any', default='none',
 
     parser.addini(
         'remote_data_strict',

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,6 @@ commands =
     pytest {toxinidir}/tests --remote-data=github {posargs}
     pytest {toxinidir}/tests --remote-data=astropy {posargs}
     pytest {toxinidir}/tests --remote-data=any {posargs}
-    pytest {toxinidir}/tests -R {posargs}
 
 [testenv:codestyle]
 changedir =


### PR DESCRIPTION
This is to fix #67, and a follow-up PR to pytest-astropy is coming.