### PR TITLE
MAINT: adding pyhon 3.12 and other CI cleanup

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -57,7 +57,7 @@ jobs:
             python-version: '3.11'
             toxenv: py311-test-pytestdev
           - os: ubuntu-latest
-            python-version: '3.12'
+            python-version: '3.12-dev'
             toxenv: py312-test-pytestdev
 
     steps:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -19,7 +19,7 @@ jobs:
         include:
           - os: macos-latest
             python-version: 3.7
-            toxenv: py37-test-pytest46
+            toxenv: py37-test-pytestoldest
           - os: ubuntu-latest
             python-version: 3.7
             toxenv: py37-test-pytest50
@@ -46,7 +46,19 @@ jobs:
             toxenv: py311-test-pytest72
           - os: ubuntu-latest
             python-version: '3.11'
+            toxenv: py310-test-pytest73
+          - os: windows-latest
+            python-version: '3.11'
+            toxenv: py310-test-pytest74
+          - os: macos-latest
+            python-version: '3.11'
             toxenv: py311-test-pytestdev
+          - os: windows-latest
+            python-version: '3.11'
+            toxenv: py311-test-pytestdev
+          - os: ubuntu-latest
+            python-version: '3.12'
+            toxenv: py312-test-pytestdev
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -60,11 +60,3 @@ jobs:
       run: python -m pip install tox
     - name: Run Tox
       run: tox -v -e ${{ matrix.toxenv }}
-
-    # - name: Slack Notification
-    #   uses: 8398a7/action-slack@v3
-    #   with:
-    #     status: ${{ job.status }}
-    #   env:
-    #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
-    #   if: always() # TODO: cron

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -7,8 +7,8 @@ on:
     tags:
   workflow_dispatch:
   schedule:
-    # Run every Sunday at 03:53 UTC
-    - cron: 53 3 * * 0
+    # Run every Tuesday at 03:53 UTC
+    - cron: 53 3 * * 2
 
 jobs:
   tests:

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ url = https://github.com/astropy/pytest-remotedata
 author = The Astropy Developers
 author_email = astropy.team@gmail.com
 classifiers =
-    Development Status :: 3 - Alpha
+    Development Status :: 5 - Production/Stable
     Framework :: Pytest
     Intended Audience :: Developers
     License :: OSI Approved :: BSD License

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Software Development :: Testing
     Topic :: Utilities

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,38,39,310,311}-test{,-devdeps}
+    py{37,38,39,310,311,312}-test{,-devdeps}
     codestyle
 requires =
     setuptools >= 30.3.0
@@ -11,7 +11,7 @@ isolated_build = true
 changedir = .tmp/{envname}
 description = run tests
 deps =
-    pytest46: pytest==4.6.*
+    pytestoldest: pytest==4.6.*
     pytest50: pytest==5.0.*
     pytest51: pytest==5.1.*
     pytest52: pytest==5.2.*
@@ -20,6 +20,8 @@ deps =
     pytest61: pytest==6.1.*
     pytest71: pytest==7.1.*
     pytest72: pytest==7.2.*
+    pytest73: pytest==7.3.*
+    pytest74: pytest==7.4.*
     pytestdev: git+https://github.com/pytest-dev/pytest#egg=pytest
 
 commands =


### PR DESCRIPTION
Extending CI matrix with new versions, adding python 3.12, and other minor cleanups. 
This should go into the next release.

I have changes that remove python 3.7 support for a separate PR, which should go in once the next release is out.