### PR TITLE
drop python<=3.7 support

### DIFF
--- a/pytest_remotedata/disable_internet.py
+++ b/pytest_remotedata/disable_internet.py
@@ -29,9 +29,9 @@ def _resolve_host_ips(hostname, port=80):
     IPv4/v6 dual stack.
     """
     try:
-        ips = set([s[-1][0] for s in socket.getaddrinfo(hostname, port)])
+        ips = {s[-1][0] for s in socket.getaddrinfo(hostname, port)}
     except socket.gaierror:
-        ips = set([])
+        ips = set()
 
     ips.add(hostname)
     return ips
@@ -59,7 +59,7 @@ def check_internet_off(original_function, allow_astropy_data=False,
                 return original_function(*args, **kwargs)
             host = args[1][0]
             addr_arg = 1
-            valid_hosts = set(['localhost', '127.0.0.1', '::1'])
+            valid_hosts = {'localhost', '127.0.0.1', '::1'}
         else:
             # The only other function this is used to wrap currently is
             # socket.create_connection, which should be passed a 2-tuple, but
@@ -69,7 +69,7 @@ def check_internet_off(original_function, allow_astropy_data=False,
 
             host = args[0][0]
             addr_arg = 0
-            valid_hosts = set(['localhost', '127.0.0.1'])
+            valid_hosts = {'localhost', '127.0.0.1'}
 
         # Astropy + GitHub data
         if allow_astropy_data:
@@ -86,7 +86,7 @@ def check_internet_off(original_function, allow_astropy_data=False,
 
         if host in (hostname, fqdn):
             host = 'localhost'
-            host_ips = set([host])
+            host_ips = {host}
             new_addr = (host, args[addr_arg][1])
             args = args[:addr_arg] + (new_addr,) + args[addr_arg + 1:]
         else:
@@ -95,9 +95,9 @@ def check_internet_off(original_function, allow_astropy_data=False,
         if len(host_ips & valid_hosts) > 0:  # Any overlap is acceptable
             return original_function(*args, **kwargs)
         else:
-            raise IOError("An attempt was made to connect to the internet "
+            raise OSError("An attempt was made to connect to the internet "
                           "by a test that was not marked `remote_data`. The "
-                          "requested host was: {0}".format(host))
+                          "requested host was: {}".format(host))
     return new_function
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,6 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -30,7 +29,7 @@ keywords = remote, data, pytest, py.test
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 setup_requires =
     setuptools_scm
 install_requires =

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,0 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)

--- a/tests/test_socketblocker.py
+++ b/tests/test_socketblocker.py
@@ -14,14 +14,14 @@ def test_outgoing_fails():
             urlopen('http://www.python.org')
 
 
-class StoppableHTTPServer(HTTPServer, object):
+class StoppableHTTPServer(HTTPServer):
     def __init__(self, *args):
-        super(StoppableHTTPServer, self).__init__(*args)
+        super().__init__(*args)
         self.stop = False
 
     def handle_request(self):
         self.stop = True
-        super(StoppableHTTPServer, self).handle_request()
+        super().handle_request()
 
     def serve_forever(self):
         """
@@ -50,7 +50,7 @@ def test_localconnect_succeeds(localhost):
     server.start()
     time.sleep(0.1)
 
-    urlopen('http://{localhost:s}:{port:d}'.format(localhost=localhost, port=port)).close()
+    urlopen(f'http://{localhost:s}:{port:d}').close()
     httpd.server_close()
 
 


### PR DESCRIPTION
According to https://endoflife.date/python python 3.7 has been EOSed 27 Jun 2023.
Filter all code over `pyupgrade --py38-plus`.