### PR TITLE
MAINT: cleanup python37 and add new versions

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -17,24 +17,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-12
-            python-version: 3.7
-            toxenv: py37-test-pytestoldest
-          - os: ubuntu-latest
-            python-version: 3.7
-            toxenv: py37-test-pytest50
-          - os: ubuntu-latest
-            python-version: 3.7
-            toxenv: py37-test-pytest51
-          - os: windows-latest
-            python-version: 3.7
-            toxenv: py37-test-pytest52
-          - os: windows-latest
-            python-version: 3.8
-            toxenv: py38-test-pytest53
           - os: ubuntu-latest
             python-version: 3.8
-            toxenv: py38-test-pytest60
+            toxenv: py38-test-pytestoldest
+          - os: windows-latest
+            python-version: 3.8
+            toxenv: py38-test-60
           - os: ubuntu-latest
             python-version: 3.9
             toxenv: py39-test-pytest61

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -44,15 +44,18 @@ jobs:
           - os: ubuntu-latest
             python-version: '3.12'
             toxenv: py312-test-pytest82
-          - os: macos-latest
+          - os: ubuntu-latest
+            python-version: '3.13'
+            toxenv: py313-test-pytest83
+            - os: macos-latest
             python-version: '3.12'
             toxenv: py312-test-pytestdev
           - os: windows-latest
-            python-version: '3.12'
-            toxenv: py312-test-pytestdev
+            python-version: '3.13'
+            toxenv: py313-test-pytestdev
           - os: ubuntu-latest
-            python-version: '3.12'
-            toxenv: py312-test-pytestdev
+            python-version: '3.13'
+            toxenv: py313-test-pytestdev
 
     steps:
     - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938  # v4.2.0

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -47,7 +47,7 @@ jobs:
           - os: ubuntu-latest
             python-version: '3.13'
             toxenv: py313-test-pytest83
-            - os: macos-latest
+          - os: macos-latest
             python-version: '3.12'
             toxenv: py312-test-pytestdev
           - os: windows-latest

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 0.4.2 (unreleased)
 ==================
 
-- No changes yet.
+- Versions of Python <3.8 are no longer supported. [#81]
 
 
 0.4.1 (2023-09-25)

--- a/pytest_remotedata/disable_internet.py
+++ b/pytest_remotedata/disable_internet.py
@@ -29,9 +29,9 @@ def _resolve_host_ips(hostname, port=80):
     IPv4/v6 dual stack.
     """
     try:
-        ips = set([s[-1][0] for s in socket.getaddrinfo(hostname, port)])
+        ips = {s[-1][0] for s in socket.getaddrinfo(hostname, port)}
     except socket.gaierror:
-        ips = set([])
+        ips = set()
 
     ips.add(hostname)
     return ips
@@ -59,7 +59,7 @@ def check_internet_off(original_function, allow_astropy_data=False,
                 return original_function(*args, **kwargs)
             host = args[1][0]
             addr_arg = 1
-            valid_hosts = set(['localhost', '127.0.0.1', '::1'])
+            valid_hosts = {'localhost', '127.0.0.1', '::1'}
         else:
             # The only other function this is used to wrap currently is
             # socket.create_connection, which should be passed a 2-tuple, but
@@ -69,7 +69,7 @@ def check_internet_off(original_function, allow_astropy_data=False,
 
             host = args[0][0]
             addr_arg = 0
-            valid_hosts = set(['localhost', '127.0.0.1'])
+            valid_hosts = {'localhost', '127.0.0.1'}
 
         # Astropy + GitHub data
         if allow_astropy_data:
@@ -86,7 +86,7 @@ def check_internet_off(original_function, allow_astropy_data=False,
 
         if host in (hostname, fqdn):
             host = 'localhost'
-            host_ips = set([host])
+            host_ips = {host}
             new_addr = (host, args[addr_arg][1])
             args = args[:addr_arg] + (new_addr,) + args[addr_arg + 1:]
         else:
@@ -95,9 +95,9 @@ def check_internet_off(original_function, allow_astropy_data=False,
         if len(host_ips & valid_hosts) > 0:  # Any overlap is acceptable
             return original_function(*args, **kwargs)
         else:
-            raise IOError("An attempt was made to connect to the internet "
+            raise OSError("An attempt was made to connect to the internet "
                           "by a test that was not marked `remote_data`. The "
-                          "requested host was: {0}".format(host))
+                          "requested host was: {}".format(host))
     return new_function
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,6 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -30,11 +29,11 @@ keywords = remote, data, pytest, py.test
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 setup_requires =
     setuptools_scm
 install_requires =
-    pytest>=4.6
+    pytest>=5.0
     packaging
 
 [options.entry_points]
@@ -46,7 +45,7 @@ exclude =
     tests
 
 [tool:pytest]
-minversion = 4.6
+minversion = 5.0
 testpaths = tests
 remote_data_strict = true
 filterwarnings = error

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Software Development :: Testing
     Topic :: Utilities

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,0 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)

--- a/tests/test_socketblocker.py
+++ b/tests/test_socketblocker.py
@@ -14,14 +14,14 @@ def test_outgoing_fails():
             urlopen('http://www.python.org')
 
 
-class StoppableHTTPServer(HTTPServer, object):
+class StoppableHTTPServer(HTTPServer):
     def __init__(self, *args):
-        super(StoppableHTTPServer, self).__init__(*args)
+        super().__init__(*args)
         self.stop = False
 
     def handle_request(self):
         self.stop = True
-        super(StoppableHTTPServer, self).handle_request()
+        super().handle_request()
 
     def serve_forever(self):
         """
@@ -50,7 +50,7 @@ def test_localconnect_succeeds(localhost):
     server.start()
     time.sleep(0.1)
 
-    urlopen('http://{localhost:s}:{port:d}'.format(localhost=localhost, port=port)).close()
+    urlopen(f'http://{localhost:s}:{port:d}').close()
     httpd.server_close()
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,7 @@ isolated_build = true
 changedir = .tmp/{envname}
 description = run tests
 deps =
-    pytestoldest: pytest==4.6.*
-    pytest50: pytest==5.0.*
+    pytestoldest: pytest==5.0.0
     pytest51: pytest==5.1.*
     pytest52: pytest==5.2.*
     pytest53: pytest==5.3.*

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,38,39,310,311,312}-test{,-devdeps}
+    py{38,39,310,311,312,313}-test{,-devdeps}
     codestyle
 requires =
     setuptools >= 30.3.0
@@ -23,6 +23,7 @@ deps =
     pytest74: pytest==7.4.*
     pytest81: pytest==8.1.*
     pytest82: pytest==8.2.*
+    pytest83: pytest==8.3.*
     pytestdev: git+https://github.com/pytest-dev/pytest#egg=pytest
 
 commands =


### PR DESCRIPTION
Some housekeeping here:

- remove python 3.7, which would also
      - remove usage of deprecated GHA VM
      - bump minimum pytest

- add python 3.13 to the test matrix
- add new pytest to the test matrix