### PR TITLE
BUGFIX: isinstance check is wrong

### DIFF
--- a/pytest_remotedata/disable_internet.py
+++ b/pytest_remotedata/disable_internet.py
@@ -51,7 +51,7 @@ def check_internet_off(original_function, allow_astropy_data=False,
     """
 
     def new_function(*args, **kwargs):
-        if isinstance(args[0], socket.socket):
+        if isinstance(args[0], socket_original):
             if not args[0].family in (socket.AF_INET, socket.AF_INET6):
                 # Should be fine in all but some very obscure cases
                 # More to the point, we don't want to affect AF_UNIX

--- a/pytest_remotedata/disable_internet.py
+++ b/pytest_remotedata/disable_internet.py
@@ -51,7 +51,10 @@ def check_internet_off(original_function, allow_astropy_data=False,
     """
 
     def new_function(*args, **kwargs):
-        if isinstance(args[0], socket_original):
+        if socket.socket != socket_original:
+            raise OSError(f"Internet status is INTERNET_OFF={INTERNET_OFF}, "
+                          "but a remote function was created.")
+        if isinstance(args[0], socket.socket):
             if not args[0].family in (socket.AF_INET, socket.AF_INET6):
                 # Should be fine in all but some very obscure cases
                 # More to the point, we don't want to affect AF_UNIX


### PR DESCRIPTION
This error:
```
E       TypeError: isinstance() arg 2 must be a type, a tuple of types, or a union
```

arises if turning internet off and then creating a new socket.  

I haven't figured out how to MWE this; it was happening in astroquery.gaia, but the source of the connection is buried behind so many abstraction layers that I'm just lost.  I've tried hard.  I would possibly recommend not merging this until/unless we have a MWE.